### PR TITLE
Bump to 2.2; remove static operator overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,6 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# VSCode
+.vscode

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,9 +1,8 @@
 ﻿<Project>
   <PropertyGroup>
     <!-- Assign these values at the end of the project after TargetFramework has been assigned. TargetFramework is not assigned yet in Directory.Build.props. -->
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">$(MicrosoftNETCoreApp11PackageVersion)</RuntimeFrameworkVersion>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(MicrosoftNETCoreApp20PackageVersion)</RuntimeFrameworkVersion>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">$(MicrosoftNETCoreApp21PackageVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">$(MicrosoftNETCoreApp22PackageVersion)</RuntimeFrameworkVersion>
     <NETStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">$(NETStandardLibrary20PackageVersion)</NETStandardImplicitPackageVersion>
   </PropertyGroup>
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -11,7 +11,7 @@
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
     <XunitAssertPackageVersion>2.3.1</XunitAssertPackageVersion>
     <XunitCorePackageVersion>2.3.1</XunitCorePackageVersion>
-    <XunitRunnerVisualStudioPackageVersion>2.4.0-beta.1.build3958</XunitRunnerVisualStudioPackageVersion>
+    <XunitRunnerVisualStudioPackageVersion>2.4.0</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,8 +1,8 @@
 {
-        "sdk": {
-            "version": "2.1.301"
-        },
-        "msbuild-sdks": {
-            "Microsoft.DotNet.GlobalTools.Sdk": "2.1.3-rtm-15802"
-        }
+    "sdk": {
+        "version": "2.2.102"
+    },
+    "msbuild-sdks": {
+        "Internal.AspNetCore.Sdk": "2.2.1-build-20190117.5"
     }
+}

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.3-rtm-15802
-commithash:a7c08b45b440a7d2058a0aa1eaa3eb6ba811976a
+version:2.2.1-build-20190117.5
+commithash:28bc5808b442f2a068bf3bff362f0aed3c5f163e

--- a/korebuild.json
+++ b/korebuild.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/release/2.1/tools/korebuild.schema.json",
-  "channel": "release/2.1"
+  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/release/2.2/tools/korebuild.schema.json",
+  "channel": "release/2.2"
 }

--- a/src/Pomelo.JsonObject/Pomelo.JsonObject.csproj
+++ b/src/Pomelo.JsonObject/Pomelo.JsonObject.csproj
@@ -9,7 +9,6 @@
     <PackageTags>JSON;Entity Framework Core;entity-framework-core;MySQL;EF;ORM</PackageTags>
     <PackageIconUrl>http://www.1234.sh/assets/Shared/pomelofoundation.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/PomeloFoundation/Pomelo.JsonObject</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/PomeloFoundation/Pomelo.JsonObject/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/PomeloFoundation/Pomelo.JsonObject.git</RepositoryUrl>
   </PropertyGroup>

--- a/src/Pomelo.JsonObject/System/JsonObject`1.cs
+++ b/src/Pomelo.JsonObject/System/JsonObject`1.cs
@@ -3,221 +3,211 @@
 // ReSharper disable once CheckNamespace
 namespace System
 {
-  public class JsonObject<T> : IEquatable<JsonObject<T>>, IEquatable<JsonObject>, IEquatable<string>
-    where T : class
-  {
-    private string _originalValue { get; set; }
-    private T _originalObject { get; set; }
-    private Type _internalType { get; set; }
-
-    public JsonObject()
+    public class JsonObject<T> : IEquatable<JsonObject<T>>, IEquatable<JsonObject>, IEquatable<string>
+      where T : class
     {
-      _internalType = typeof(T);
-    }
+        private string _originalValue { get; set; }
+        private T _originalObject { get; set; }
+        private Type _internalType { get; set; }
 
-    public JsonObject(T instance)
-      : this()
-    {
-      Object = instance;
-    }
-
-    public JsonObject(string json)
-      : this()
-    {
-      Json = json;
-      Object = Object;
-    }
-
-    public JsonObject(byte[] json)
-      : this()
-    {
-      Json = Text.Encoding.UTF8.GetString(json);
-      Object = Object;
-    }
-
-    public T Object
-    {
-      get { return _originalObject; }
-      set
-      {
-        _originalObject = value;
-
-        _originalValue = _originalObject != null
-          ? SerializeObject(Object)
-          : string.Empty;
-      }
-    }
-
-    public string Json
-    {
-      get { return _originalValue; }
-      set
-      {
-        try
+        public JsonObject()
         {
-          Object = string.IsNullOrWhiteSpace(value)
-            ? default(T)
-            : DeserializeObject<T>(value);
-
-          _originalValue = value;
+            _internalType = typeof(T);
         }
-        catch
+
+        public JsonObject(T instance)
+          : this()
         {
-          Object = null;
-          _originalValue = string.Empty;
+            Object = instance;
         }
-      }
+
+        public JsonObject(string json)
+          : this()
+        {
+            Json = json;
+            Object = Object;
+        }
+
+        public JsonObject(byte[] json)
+          : this()
+        {
+            Json = Text.Encoding.UTF8.GetString(json);
+            Object = Object;
+        }
+
+        public T Object
+        {
+            get { return _originalObject; }
+            set
+            {
+                _originalObject = value;
+
+                _originalValue = _originalObject != null
+                  ? SerializeObject(Object)
+                  : string.Empty;
+            }
+        }
+
+        public string Json
+        {
+            get { return _originalValue; }
+            set
+            {
+                try
+                {
+                    Object = string.IsNullOrWhiteSpace(value)
+                      ? default(T)
+                      : DeserializeObject<T>(value);
+
+                    _originalValue = value;
+                }
+                catch
+                {
+                    Object = null;
+                    _originalValue = string.Empty;
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return Json;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null && Json == Null)
+                return true;
+
+            if (obj.GetType().Name == "String")
+            {
+                var objString = obj as string;
+                if (objString == NaN && Json == NaN)
+                    return false;
+
+                return Equals(objString);
+            }
+
+            try
+            {
+                dynamic o = obj;
+                return Equals((string)o.Json);
+            }
+            catch
+            {
+                return base.Equals(obj);
+            }
+        }
+
+        public bool Equals(JsonObject<T> other)
+        {
+            if (other == null && Json == Null)
+                return true;
+
+            return Equals(other.Json);
+        }
+
+        public bool Equals(JsonObject other)
+        {
+            if (other == null && Json == Null)
+                return true;
+
+            return Equals(other.Json);
+        }
+
+        public bool Equals(string other)
+        {
+            if (other == NaN && Json == NaN)
+                return false;
+
+            if (string.IsNullOrWhiteSpace(other) || IsJsonConstant(other))
+                return string.CompareOrdinal(other, Json) == 0;
+
+            if (!IsSameType(Json, other))
+                return false;
+
+            var tempJsonObject = new JsonObject(other);
+            return GetHashCode() == tempJsonObject.GetHashCode();
+        }
+
+        private Type GetInternalObjectType()
+        {
+            return _internalType;
+        }
+
+        public static implicit operator JsonObject<T>(byte[] json)
+        {
+            return new JsonObject<T>(json);
+        }
+
+        public static implicit operator JsonObject<T>(string json)
+        {
+            return new JsonObject<T>(json);
+        }
+
+        public static implicit operator JsonObject<T>(T obj)
+        {
+            return new JsonObject<T>(obj);
+        }
+
+        public static implicit operator JsonObject<T>(JsonObject<object> obj)
+        {
+            return new JsonObject<T>(obj.Json);
+        }
+
+        private static bool IsObject(string json)
+        {
+            JsonObject jsonObject;
+            return IsObject(json, out jsonObject);
+        }
+
+        private static bool IsObject(string json, out JsonObject jsonObject)
+        {
+            jsonObject = null;
+
+            if (string.IsNullOrWhiteSpace(json) || IsJsonConstant(json))
+                return false;
+
+            if (string.CompareOrdinal(json, Null) == 0)
+                return true;
+
+            jsonObject = new JsonObject(json);
+
+            return jsonObject.Object != null;
+        }
+
+        private static bool IsJsonConstant(string json)
+        {
+            if (string.CompareOrdinal(json, NaN) == 0 ||
+                string.CompareOrdinal(json, Undefined) == 0 ||
+                string.CompareOrdinal(json, True) == 0 ||
+                string.CompareOrdinal(json, False) == 0 ||
+                string.CompareOrdinal(json, NegativeInfinity) == 0 ||
+                string.CompareOrdinal(json, PositiveInfinity) == 0)
+                return true;
+
+            return false;
+        }
+
+        private static bool IsSameType(string json1, string json2)
+        {
+            if (string.IsNullOrWhiteSpace(json1) && string.IsNullOrWhiteSpace(json2)
+                || json1 == Null && json2 == Null)
+                return true;
+
+            if (IsJsonConstant(json1) && IsJsonConstant(json2))
+                return json1 == json2;
+
+            JsonObject left, right;
+            if (!IsObject(json1, out left) || !IsObject(json2, out right))
+                return false;
+
+            return left.GetInternalObjectType().FullName == right.GetInternalObjectType().FullName;
+        }
+
+        public override int GetHashCode()
+        {
+            return Json?.GetHashCode() ?? 0;
+        }
     }
-
-    public override string ToString()
-    {
-      return Json;
-    }
-
-    public override bool Equals(object obj)
-    {
-      if (obj == null && Json == Null)
-        return true;
-
-      if (obj.GetType().Name == "String")
-      {
-        var objString = obj as string;
-        if (objString == NaN && Json == NaN)
-          return false;
-
-        return Equals(objString);
-      }
-
-      try
-      {
-        dynamic o = obj;
-        return Equals((string) o.Json);
-      }
-      catch
-      {
-        return base.Equals(obj);
-      }
-    }
-
-    public bool Equals(JsonObject<T> other)
-    {
-      if (other == null && Json == Null)
-        return true;
-
-      return Equals(other.Json);
-    }
-
-    public bool Equals(JsonObject other)
-    {
-      if (other == null && Json == Null)
-        return true;
-
-      return Equals(other.Json);
-    }
-
-    public bool Equals(string other)
-    {
-      if (other == NaN && Json == NaN)
-        return false;
-
-      if (string.IsNullOrWhiteSpace(other) || IsJsonConstant(other))
-        return string.CompareOrdinal(other, Json) == 0;
-
-      if (!IsSameType(Json, other))
-        return false;
-
-      var tempJsonObject = new JsonObject(other);
-      return GetHashCode() == tempJsonObject.GetHashCode();
-    }
-
-    private Type GetInternalObjectType()
-    {
-      return _internalType;
-    }
-
-    public static implicit operator JsonObject<T>(byte[] json)
-    {
-      return new JsonObject<T>(json);
-    }
-
-    public static implicit operator JsonObject<T>(string json)
-    {
-      return new JsonObject<T>(json);
-    }
-
-    public static implicit operator JsonObject<T>(T obj)
-    {
-      return new JsonObject<T>(obj);
-    }
-
-    public static implicit operator JsonObject<T>(JsonObject<object> obj)
-    {
-      return new JsonObject<T>(obj.Json);
-    }
-
-    private static bool IsObject(string json)
-    {
-      JsonObject jsonObject;
-      return IsObject(json, out jsonObject);
-    }
-
-    private static bool IsObject(string json, out JsonObject jsonObject)
-    {
-      jsonObject = null;
-
-      if (string.IsNullOrWhiteSpace(json) || IsJsonConstant(json))
-        return false;
-
-      if (string.CompareOrdinal(json, Null) == 0)
-        return true;
-
-      jsonObject = new JsonObject(json);
-
-      return jsonObject.Object != null;
-    }
-
-    private static bool IsJsonConstant(string json)
-    {
-      if (string.CompareOrdinal(json, NaN) == 0 ||
-          string.CompareOrdinal(json, Undefined) == 0 ||
-          string.CompareOrdinal(json, True) == 0 ||
-          string.CompareOrdinal(json, False) == 0 ||
-          string.CompareOrdinal(json, NegativeInfinity) == 0 ||
-          string.CompareOrdinal(json, PositiveInfinity) == 0)
-        return true;
-
-      return false;
-    }
-
-    private static bool IsSameType(string json1, string json2)
-    {
-      if (string.IsNullOrWhiteSpace(json1) && string.IsNullOrWhiteSpace(json2)
-          || json1 == Null && json2 == Null)
-        return true;
-
-      if (IsJsonConstant(json1) && IsJsonConstant(json2))
-        return json1 == json2;
-
-      JsonObject left, right;
-      if (!IsObject(json1, out left) || !IsObject(json2, out right))
-        return false;
-
-      return left.GetInternalObjectType().FullName == right.GetInternalObjectType().FullName;
-    }
-
-    public static bool operator ==(JsonObject<T> a, JsonObject<T> b)
-    {
-      return a.Equals(b);
-    }
-
-    public static bool operator !=(JsonObject<T> a, JsonObject<T> b)
-    {
-      return !a.Equals(b);
-    }
-
-    public override int GetHashCode()
-    {
-      return Json?.GetHashCode() ?? 0;
-    }
-  }
 }

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,9 +2,9 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <DeveloperBuildTestTfms>netcoreapp2.1</DeveloperBuildTestTfms>
+    <DeveloperBuildTestTfms>netcoreapp2.2</DeveloperBuildTestTfms>
     <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
-    <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'True' ">netcoreapp2.0;netcoreapp2.1</StandardTestTfms>
+    <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'True' ">$(StandardTestTfms);netcoreapp2.0</StandardTestTfms>
     <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'True' AND '$(CoreOnly)' != 'True' AND '$(OS)' == 'Windows_NT' ">net461;$(StandardTestTfms)</StandardTestTfms>
   </PropertyGroup>
 

--- a/version.props
+++ b/version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
-    <VersionSuffix>rtm</VersionSuffix>
+    <VersionPrefix>2.2.0</VersionPrefix>
+    <VersionSuffix>preview1</VersionSuffix>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
     <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>


### PR DESCRIPTION
The static operator overrides were causing a Null Pointer Exception in `Pomelo.EntityFrameworkCore.MySql` version 2.2.0.  Removing them fixes the problem and seems to have no negative effect.